### PR TITLE
fix issue in linux java page

### DIFF
--- a/docs/java/linux.md
+++ b/docs/java/linux.md
@@ -10,5 +10,5 @@ title: Java Edition for Linux
 
 | Name | Download | Source code | Is it maintained? | Description
 | ------ | ------ | ------ | ------ | ------
-| ⭐ PrismLauncher | [Website](https://prismlauncher.org/) | [Github](https://github.com/PrismLauncher/PrismLauncher) | Yes | A feature-rich launcher, preferred by many (Doesnt support cracked, refer to [here](https://mcdoc.site/java/windows#prism-launcher-tools)
+| ⭐ PrismLauncher | [Website](https://prismlauncher.org/) | [Github](https://github.com/PrismLauncher/PrismLauncher) | Yes | A feature-rich launcher, preferred by many (Doesnt support cracked, refer to [here](https://mcdoc.site/java/windows#prism-launcher-tools))
 | ⭐ ElyPrismLauncher | [Github](https://github.com/Octol1ttle/ElyPrismLauncher) | A remake of Prism Launcher with Ely.By and Offline Account features.

--- a/docs/java/linux.md
+++ b/docs/java/linux.md
@@ -10,5 +10,5 @@ title: Java Edition for Linux
 
 | Name | Download | Source code | Is it maintained? | Description
 | ------ | ------ | ------ | ------ | ------
-| ⭐ PrismLauncher | [Website](https://prismlauncher.org/) | [Github](https://github.com/PrismLauncher/PrismLauncher) | Yes | A feature-rich launcher, preferred by many (Doesnt support cracked, refer to [here](#prism-launcher-tools))
+| ⭐ PrismLauncher | [Website](https://prismlauncher.org/) | [Github](https://github.com/PrismLauncher/PrismLauncher) | Yes | A feature-rich launcher, preferred by many (Doesnt support cracked, refer to [here](https://mcdoc.site/java/windows#prism-launcher-tools)
 | ⭐ ElyPrismLauncher | [Github](https://github.com/Octol1ttle/ElyPrismLauncher) | A remake of Prism Launcher with Ely.By and Offline Account features.


### PR DESCRIPTION
see here:
<img width="870" height="249" alt="image" src="https://github.com/user-attachments/assets/f6ab251a-61d9-449e-9ad1-9fc210617a72" />

the "here" links to nothing, or what i assume a now deleted prism launcher tools section but for linux.

anyways, both of the resources in windows prism launcher tools work with linux or have a linux option.